### PR TITLE
Revert repo value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "helm_release" "aad_pod_identity" {
   depends_on = [azurerm_role_assignment.k8s_virtual_machine_contributor, azurerm_role_assignment.k8s_managed_identity_operator,azurerm_role_assignment.additional_managed_identity_operator]
   name       = "aad-pod-identity"
   namespace  = "kube-system"
-  repository = "aad-pod-identity"
+  repository = "https://raw.githubusercontent.com/Azure/aad-pod-identity/master/charts"
   chart      = "aad-pod-identity"
   version    = var.helm_chart_version
 


### PR DESCRIPTION
Not sure if this change was done for local testing or there is a config somewhere I need to add in TFE to support helm repos?

Below is the current error I get when I use the rewrite branch. The old value on masterworks fine though. TFE doesn't have any local helm repos that I know of so this lookup fails. 
```
Error: failed to download "aad-pod-identity/aad-pod-identity" (hint: running `helm repo update` may help)

  on .terraform/modules/aad_pod_identity/main.tf line 40, in resource "helm_release" "aad_pod_identity":
  40: resource "helm_release" "aad_pod_identity" {
```