### PR TITLE
wait for aad_pod_identities chart before creating identities

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -38,6 +38,7 @@ resource "helm_release" "aad_pod_identity" {
 }
 
 module "identity" {
+  depends_on = [ helm_release.aad_pod_identity ]
   source   = "./identity"
   for_each = (var.identities == null ? {} : var.identities)
 


### PR DESCRIPTION
Without this `depends_on` the identities charts start installing immediately, before `aad_pod_identity` is finished installing. Not having this causes the terraform apply run to fail with obscure errors about missing CRDs.