### PR TITLE
Pause between pod identity installation and creation of the AzureIdentity

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,4 +1,4 @@
-locals = {
+locals {
     ##
     # If CRDs are installed and we are going to create AzureIdentity right away
     #  set a pause time between installation of pod identity and the creation

--- a/locals.tf
+++ b/locals.tf
@@ -3,6 +3,6 @@ locals {
     # If CRDs are installed and we are going to create AzureIdentity right away
     #  set a pause time between installation of pod identity and the creation
     #  of the AzureIdentity.  Otherwise there is a chance of failure.
-    identity_creation_quiessence_time_in_secs = var.install_crds && var.identities != null ? 30 : 0 
+    identity_creation_quiessence_time_in_secs = var.install_crds && var.identities != null ? 30 : 1 
 
 }

--- a/locals.tf
+++ b/locals.tf
@@ -1,0 +1,7 @@
+locals = {
+    ##
+    # If CRDs are installed and we are going to create AzureIdentity right away
+    #  set a pause time between installation of pod identity and the creation
+    #  of the AzureIdentity.  Otherwise there is a chance of failure.
+    identity_creation_quiessence_time_in_secs = (var.install_crds and var.identities != null) ? 30 : 0
+}

--- a/locals.tf
+++ b/locals.tf
@@ -3,5 +3,5 @@ locals = {
     # If CRDs are installed and we are going to create AzureIdentity right away
     #  set a pause time between installation of pod identity and the creation
     #  of the AzureIdentity.  Otherwise there is a chance of failure.
-    identity_creation_quiessence_time_in_secs = (var.install_crds and var.identities != null) ? 30 : 0
+    identity_creation_quiessence_time_in_secs = (var.install_crds and var.identities != null ? 30 : 0 )
 }

--- a/locals.tf
+++ b/locals.tf
@@ -3,5 +3,6 @@ locals {
     # If CRDs are installed and we are going to create AzureIdentity right away
     #  set a pause time between installation of pod identity and the creation
     #  of the AzureIdentity.  Otherwise there is a chance of failure.
-    identity_creation_quiessence_time_in_secs = (var.install_crds and var.identities != null ? 30 : 0 )
+    identity_creation_quiessence_time_in_secs = var.install_crds && var.identities != null ? 30 : 0 
+
 }


### PR DESCRIPTION
Background:
During a fresh install of pod identity if an AzureIdentity is created via helm immediately after installation of the pod identity chart sometimes the creation of the identity fails complaining that K8s doesn't know about the type "aadpodidentity.k8s.io/v1 AzureIdentity".  This is because the CRDs from pod identity are not immediately applied, even though helm reports that pod identity has been successfully installed.

Fix:
 Wait 30 seconds to add the AzureIdentity after pod identity has been installed.  We only need to wait if CRDs are installed and the caller is requesting to add individual identities.
